### PR TITLE
Use new Codex CLI invocation

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -19,7 +19,7 @@ NETWORK_EXCEPTIONS = (
 
 
 def run_codex_cli(prompt: str, max_retries: int = 3, timeout: Optional[int] = None) -> str:
-    """Run the OpenAI codex CLI with retry logic on timeouts.
+    """Run the Codex CLI non-interactively with retry logic on timeouts.
 
     Args:
         prompt: The prompt to pass to the codex CLI.
@@ -36,7 +36,7 @@ def run_codex_cli(prompt: str, max_retries: int = 3, timeout: Optional[int] = No
     for attempt in range(max_retries):
         try:
             result = subprocess.run(
-                ["openai", "codex", "--prompt", prompt],
+                ["codex", "exec", prompt],
                 capture_output=True,
                 check=True,
                 text=True,


### PR DESCRIPTION
## Summary
- run Codex via `codex exec` with positional prompt
- clarify docstring for new CLI usage

## Testing
- `python -m py_compile openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c4921348324b14810dd97ab7fae