### PR TITLE
Silence urllib3 SSL warning

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,6 +1,13 @@
 import subprocess
 import time
+import warnings
 from typing import Optional
+
+# Suppress urllib3 warning about unsupported SSL implementations
+warnings.filterwarnings(
+    "ignore",
+    message="urllib3 v2 only supports OpenSSL",
+)
 
 from openai import (
     APIConnectionError,


### PR DESCRIPTION
## Summary
- suppress urllib3's NotOpenSSLWarning to hide LibreSSL warning on import

## Testing
- `python -m py_compile openai_utils.py orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb44f1ba2483248b6b15fe2918a9de