### PR TITLE
Add placeholder interpolation and concurrency cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,23 @@ Run the orchestrator with the path to this file:
 python orchestrator.py path/to/config.json --parallel 10
 ```
 
-The `--parallel` flag controls how many end-to-end flows are executed in parallel.
+The `--parallel` flag sets a **maximum** number of flows that may run
+concurrently. When more flows are scheduled, they queue until a slot becomes
+available.
+
+You can also supply files whose contents are interpolated into the prompts of
+each flow. Each `--key` flag specifies a placeholder and a text file containing
+line-separated file paths. The contents of those files are inserted wherever the
+placeholder appears in the prompt. The number of lines across the referenced
+files determines how many total flows are executed.
+
+```bash
+python orchestrator.py config.json --parallel 10 --key foo:paths.txt
+```
+
 While running, the orchestrator logs a live view of the number of active flows at
-each step. For a configuration such as `openai -> codex -> openai`, the log might
-look like:
+each step, along with overall progress `finished/total`. For a configuration such
+as `openai -> codex -> openai`, the log might look like:
 
 ```
 openai: 1 -> codex: 0 -> openai: 1


### PR DESCRIPTION
## Summary
- Limit orchestrator `--parallel` flag to a concurrency cap instead of total workers
- Add `--key` flag for placeholder interpolation from line-separated file lists
- Display finished/total flow progress alongside step counts

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `python orchestrator.py config.json --parallel 1 --key foo:paths.txt` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb46bbea508324aa23299d582cd19d