### PR TITLE
Support Cartesian key interpolation in flow generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ available.
 You can also supply files whose contents are interpolated into the prompts of
 each flow. Each `--key` flag specifies a placeholder and a text file containing
 line-separated file paths. The contents of those files are inserted wherever the
-placeholder appears in the prompt. The number of lines across the referenced
-files determines how many total flows are executed.
+placeholder appears in the prompt. Flows are generated for every combination of
+lines across the supplied files, so the total number of flows equals the
+product of the line counts for each key file.
 
 ```bash
 python orchestrator.py config.json --parallel 10 --key foo:paths.txt


### PR DESCRIPTION
## Summary
- Generate flow configurations for every combination of key file contents instead of pairing by index
- Document combinatorial placeholder expansion in README

## Testing
- `python -m py_compile orchestrator.py`
- `python - <<'PY'
import json
from pathlib import Path
from orchestrator import _generate_flow_configs

with open('config.json', 'r') as f:
    config = json.load(f)
key_files = {'a': Path('listA.txt'), 'b': Path('listB.txt')}
flows = _generate_flow_configs(config, key_files)
print('num_flows', len(flows))
for flow in flows:
    prompts = [step['prompt'] for step in flow]
    print(prompts)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb47ebfab08324b766b70bee75cfd8