### PR TITLE
Use triple-brace placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ available.
 
 You can also supply files whose contents are interpolated into the prompts of
 each flow. Each `--key` flag specifies a placeholder and a text file containing
-line-separated file paths. The contents of those files are inserted wherever the
+line-separated file paths. Placeholders must be wrapped in triple braces (e.g.
+`{{{foo}}}`). The contents of those files are inserted wherever the matching
 placeholder appears in the prompt. Flows are generated for every combination of
 lines across the supplied files, so the total number of flows equals the
 product of the line counts for each key file.
@@ -33,6 +34,9 @@ product of the line counts for each key file.
 ```bash
 python orchestrator.py config.json --parallel 10 --key foo:paths.txt
 ```
+
+Any prompt containing `{{{foo}}}` will have that placeholder replaced with the
+contents of each file listed in `paths.txt`.
 
 While running, the orchestrator logs a live view of the number of active flows at
 each step, along with overall progress `finished/total`. For a configuration such

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -51,7 +51,10 @@ def _generate_flow_configs(
     base_config: List[Dict[str, Any]],
     key_files: Dict[str, Path],
 ) -> List[List[Dict[str, Any]]]:
-    """Expand a base configuration into multiple flows via placeholder files."""
+    """Expand a base configuration into multiple flows via placeholder files.
+
+    Placeholders in prompts must be wrapped with triple braces, e.g. ``{{{name}}}``.
+    """
 
     if not key_files:
         return [base_config]
@@ -75,7 +78,8 @@ def _generate_flow_configs(
             new_step = dict(step)
             prompt = new_step.get("prompt", "")
             for key, value in mapping.items():
-                prompt = prompt.replace(f"{{{key}}}", value)
+                placeholder = "{{{" + key + "}}}"
+                prompt = prompt.replace(placeholder, value)
             new_step["prompt"] = prompt
             flow.append(new_step)
         flow_configs.append(flow)
@@ -172,7 +176,7 @@ if __name__ == "__main__":
         "--key",
         action="append",
         default=[],
-        help="Placeholder interpolation in the form name:filelist.txt",
+        help="Placeholder interpolation in the form name:filelist.txt (use {{{name}}} in prompts)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Require triple-brace placeholders when generating flow configurations to avoid accidental replacements
- Document triple-brace placeholder usage in README and CLI help

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `OPENAI_API_KEY=dummy python orchestrator.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bb503ec2e48324bfca42b259b1df24