### PR TITLE
feat: allow custom step names in progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A simple configurable orchestration system that chains Codex and OpenAI model ca
 
 ## Usage
 
-Create a JSON configuration describing each step. Each item requires a `type` (`"codex"` or `"openai"`) and a `prompt`.
+Create a JSON configuration describing each step. Each item requires a `type`
+(`"codex"` or `"openai"`) and a `prompt`. You can optionally supply a
+`name` to use in the live progress output instead of the step type.
 
 ```json
 [
-  {"type": "openai", "prompt": "Write a limerick about orchestration."},
-  {"type": "openai", "prompt": "Summarize the previous output."}
+  {"type": "openai", "name": "draft", "prompt": "Write a limerick about orchestration."},
+  {"type": "openai", "name": "summary", "prompt": "Summarize the previous output."}
 ]
 ```
 
@@ -39,15 +41,16 @@ Any prompt containing `{{{foo}}}` will have that placeholder replaced with the
 contents of each file listed in `paths.txt`.
 
 While running, the orchestrator logs a live view of the number of active flows at
-each step, along with overall progress `finished/total`. For a configuration such
-as `openai -> codex -> openai`, the log might look like:
+each step, along with overall progress `finished/total`. If a step includes a
+`name`, that value appears in the log instead of the step's `type`. For a
+configuration such as `draft -> codex -> summary`, the log might look like:
 
 ```
-openai: 1 -> codex: 0 -> openai: 1
+draft: 1 -> codex: 0 -> summary: 1
 ```
 
-indicating one flow is at the first OpenAI step and another is nearing completion
-at the final OpenAI step.
+indicating one flow is at the first step and another is nearing completion at
+the final step.
 
 Each step receives the output of the previous step appended to its prompt. When
 the final step is handled by the codex CLI, its concluding message is written to

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -103,10 +103,14 @@ def orchestrate(
     """Execute multiple flows with a concurrency cap while logging active counts.
 
     Returns a list of tuples containing each flow's final message and the path to
-    the file holding that message when produced by a codex step.
+    the file holding that message when produced by a codex step. Each step may
+    optionally define a ``name`` field, which is used in the live progress output
+    instead of the underlying step ``type``.
     """
 
-    step_names = [step.get("type", "") for step in base_config]
+    # Prefer a user-defined name for each step when displaying progress; fall back
+    # to the step's type (e.g. "codex" or "openai") if no custom name is given.
+    step_names = [step.get("name") or step.get("type", "") for step in base_config]
     step_counts = [0] * len(base_config)
     step_lock = threading.Lock()
     progress_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- support optional `name` field per step to override the phase label in progress logs
- document custom step names in README

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8cf2810c8324803a9f355111923f