### PR TITLE
Preserve Codex outputs in generated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+generated/*
+!generated/.gitkeep
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ at the final OpenAI step.
 
 Each step receives the output of the previous step appended to its prompt. When
 the final step is handled by the codex CLI, its concluding message is written to
-a file inside a temporary directory. The script prints the path so downstream
-code can read the message:
+a file inside the `generated` directory so it remains available after the run.
+The script prints the path so downstream code can read the message:
 
 ```python
-with open("/tmp/codex_exec_xxxx/final_message.txt") as f:
+with open("generated/codex_exec_xxxx/final_message.txt") as f:
     final_message = f.read()
 ```
 
-The temporary directory is left intact for logging.
+The directory is left intact for logging.
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -11,6 +11,10 @@ warnings.filterwarnings(
     message="urllib3 v2 only supports OpenSSL",
 )
 
+# Directory for preserving Codex outputs
+GENERATED_DIR = Path("generated")
+GENERATED_DIR.mkdir(parents=True, exist_ok=True)
+
 from openai import (
     APIConnectionError,
     APITimeoutError,
@@ -58,7 +62,7 @@ def run_codex_cli(
         immediately.
     """
     for attempt in range(max_retries):
-        tmpdir = Path(tempfile.mkdtemp(prefix="codex_exec_"))
+        tmpdir = Path(tempfile.mkdtemp(prefix="codex_exec_", dir=GENERATED_DIR))
         output_path = tmpdir / "final_message.txt"
         try:
             subprocess.run(

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import tempfile
 
-from openai_utils import call_openai_api, run_codex_cli
+from openai_utils import GENERATED_DIR, call_openai_api, run_codex_cli
 
 
 def _run_flow(
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     results = orchestrate(config, flow_configs, parallel=args.parallel)
     for idx, (res, path) in enumerate(results):
         if path is None:
-            tmpdir = Path(tempfile.mkdtemp(prefix="codex_run_"))
+            tmpdir = Path(tempfile.mkdtemp(prefix="codex_run_", dir=GENERATED_DIR))
             filename = (
                 "final_message.txt" if len(results) == 1 else f"final_message_{idx}.txt"
             )


### PR DESCRIPTION
## Summary
- Ensure Codex CLI results are stored under a persistent `generated/` folder
- Persist final messages from non-Codex flows in `generated/`
- Document generated output location and ignore runtime artifacts

## Testing
- `python -m py_compile openai_utils.py orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb8d309b348324a30c52936956da88