### PR TITLE
Display Codex stderr on exec failure

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -90,6 +90,10 @@ def run_codex_cli(
             if attempt == max_retries - 1:
                 raise
             time.sleep(1)
+        except subprocess.CalledProcessError as e:
+            # Surface stderr from the Codex CLI when execution fails.
+            print(e.stderr)
+            raise
         except Exception:
             # Any non-timeout exception should fail fast.
             raise


### PR DESCRIPTION
## Summary
- surface Codex CLI stderr when `codex exec` fails to help debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb92969e748324985b5864bfdecd24