### PR TITLE
Add optional flag to append source file paths during placeholder interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ python orchestrator.py config.json --parallel 10 --key foo:paths.txt
 ```
 
 Any prompt containing `{{{foo}}}` will have that placeholder replaced with the
-contents of each file listed in `paths.txt`.
+contents of each file listed in `paths.txt`. Use `--append-filepath` to append
+the path of each interpolated file after its contents in the prompt.
 
 While running, the orchestrator logs a live view of the number of active flows at
 each step, along with overall progress `finished/total`. If a step includes a


### PR DESCRIPTION
## Summary
- allow `_generate_flow_configs` to optionally append the originating file path to placeholder content
- expose this behavior via a new `--append-filepath` CLI flag
- document the new flag in the README

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bca5ca56488324a2c8376cd86ec964