### PR TITLE
Handle Codex and OpenAI errors

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -15,6 +15,10 @@ warnings.filterwarnings(
 GENERATED_DIR = Path("generated")
 GENERATED_DIR.mkdir(parents=True, exist_ok=True)
 
+# Directory for preserving errors from Codex and OpenAI calls
+ERROR_DIR = GENERATED_DIR / "errors"
+ERROR_DIR.mkdir(parents=True, exist_ok=True)
+
 from openai import (
     APIConnectionError,
     APITimeoutError,
@@ -91,9 +95,9 @@ def run_codex_cli(
                 raise
             time.sleep(1)
         except subprocess.CalledProcessError as e:
-            # Surface stderr from the Codex CLI when execution fails.
-            print(e.stderr)
-            raise
+            # Include stderr from the Codex CLI in the raised exception for logging.
+            msg = e.stderr or str(e)
+            raise Exception(msg) from e
         except Exception:
             # Any non-timeout exception should fail fast.
             raise


### PR DESCRIPTION
## Summary
- Log Codex and OpenAI failures to dedicated error directories per run
- Prevent orchestration crashes by capturing step exceptions and writing error files

## Testing
- `python -m py_compile openai_utils.py orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcab727b008324b17b6801ef64d77b