### PR TITLE
Group Codex outputs by flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,17 @@ draft: 1 -> codex: 0 -> summary: 1
 indicating one flow is at the first step and another is nearing completion at
 the final step.
 
-Each step receives the output of the previous step appended to its prompt. When
-the final step is handled by the codex CLI, its concluding message is written to
-a file inside the `generated` directory so it remains available after the run.
-The script prints the path so downstream code can read the message:
+Each step receives the output of the previous step appended to its prompt. Each
+flow has its own directory inside `generated`, and Codex invocations create
+subdirectories within that flow. When the final step is handled by the codex
+CLI, its concluding message is written to a file in the flow's directory so it
+remains available after the run. The script prints the path so downstream code
+can read the message:
 
 ```python
-with open("generated/codex_exec_xxxx/final_message.txt") as f:
+with open("generated/flow_xxxx/codex_exec_xxxx/final_message.txt") as f:
     final_message = f.read()
 ```
 
-The directory is left intact for logging.
+Each flow directory is left intact for logging.
 

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -15,10 +15,6 @@ warnings.filterwarnings(
 GENERATED_DIR = Path("generated")
 GENERATED_DIR.mkdir(parents=True, exist_ok=True)
 
-# Directory for preserving errors from Codex and OpenAI calls
-ERROR_DIR = GENERATED_DIR / "errors"
-ERROR_DIR.mkdir(parents=True, exist_ok=True)
-
 from openai import (
     APIConnectionError,
     APITimeoutError,
@@ -45,6 +41,7 @@ NETWORK_EXCEPTIONS = (
 def run_codex_cli(
     prompt: str,
     workdir: Path,
+    output_dir: Path,
     max_retries: int = 3,
     timeout: Optional[int] = None,
 ) -> Tuple[str, Path]:
@@ -57,6 +54,7 @@ def run_codex_cli(
     Args:
         prompt: The prompt to pass to the codex CLI.
         workdir: Directory to run the codex command from.
+        output_dir: Base directory to store Codex output.
         max_retries: Maximum number of retries when a timeout occurs.
         timeout: Optional timeout for the subprocess call in seconds.
 
@@ -70,7 +68,7 @@ def run_codex_cli(
         immediately.
     """
     for attempt in range(max_retries):
-        tmpdir = Path(tempfile.mkdtemp(prefix="codex_exec_", dir=GENERATED_DIR))
+        tmpdir = Path(tempfile.mkdtemp(prefix="codex_exec_", dir=output_dir))
         output_path = tmpdir / "final_message.txt"
         try:
             subprocess.run(


### PR DESCRIPTION
## Summary
- Create a dedicated directory under `generated` for each flow
- Record Codex and error outputs within each flow's directory
- Update documentation for new output layout

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `OPENAI_API_KEY=test python orchestrator.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bcc6e8ccbc83249dd8546baef1545c