### PR TITLE
Support custom command steps in orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ A simple configurable orchestration system that chains Codex and OpenAI model ca
 
 ## Usage
 
-Create a JSON configuration describing each step. Each item requires a `type`
-(`"codex"` or `"openai"`) and a `prompt`. You can optionally supply a
-`name` to use in the live progress output instead of the step type.
+Create a JSON configuration describing each step. For built-in model calls, each
+item requires a `type` (`"codex"` or `"openai"`) and a `prompt`. You can
+optionally supply a `name` to use in the live progress output instead of the
+step type. Steps may also include a `cmd` field to run an arbitrary shell
+command; the previous step's output is piped to the command's standard input and
+its standard output is passed to the next step.
 
 ```json
 [
   {"type": "openai", "name": "draft", "prompt": "Write a limerick about orchestration."},
-  {"type": "openai", "name": "summary", "prompt": "Summarize the previous output."}
+  {"type": "openai", "name": "summary", "prompt": "Summarize the previous output."},
+  {"type": "shout", "cmd": "tr '[:lower:]' '[:upper:]'"}
 ]
 ```
 


### PR DESCRIPTION
## Summary
- allow config steps with `cmd` to run shell commands and feed their stdout to subsequent stages
- expand flow generation to interpolate placeholders in `cmd`
- document `cmd` usage in README

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`
- `python orchestrator.py test_config.json --workdir .`

------
https://chatgpt.com/codex/tasks/task_e_68c07874d97883249b0b3b3f1940c06b