### PR TITLE
Add array-based branching to orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ with open("generated/flow_xxxx/codex_exec_xxxx/final_message.txt") as f:
 
 Each flow directory is left intact for logging.
 
+### Branching with arrays
+
+Add an `"array": true` field to any step that is expected to produce a JSON
+array. The orchestrator parses the array and runs the remaining steps once for
+each element in parallel. Each element is passed to the next phase as the
+previous step's output, and the final results from all branches are returned as
+separate flow outputs.
+


### PR DESCRIPTION
## Summary
- support `"array": true` flag on steps to branch flows for each JSON array element
- collect branch results and flow directories via updated concurrency worker
- document array branching in README

## Testing
- `python -m py_compile orchestrator.py`
- `python orchestrator.py test_config.json --workdir .` *(with sample config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0847df8d883249c3914dfc6db4cb1