### PR TITLE
Stream Codex stdout to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ the final step.
 
 Each step receives the output of the previous step appended to its prompt. Each
 flow has its own directory inside `generated`, and Codex invocations create
-subdirectories within that flow. When the final step is handled by the codex
-CLI, its concluding message is written to a file in the flow's directory so it
-remains available after the run. The script prints the path so downstream code
-can read the message:
+subdirectories within that flow. During execution, the Codex process's standard
+output is streamed to `stdout.txt` in its subdirectory. When the final step is
+handled by the codex CLI, its concluding message is written to
+`final_message.txt` in the same location so it remains available after the run.
+The script prints the path so downstream code can read the message:
 
 ```python
 with open("generated/flow_xxxx/codex_exec_xxxx/final_message.txt") as f:


### PR DESCRIPTION
## Summary
- stream Codex CLI stdout to `stdout.txt` in each execution directory
- document new `stdout.txt` log alongside `final_message.txt`

## Testing
- `python -m py_compile openai_utils.py orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5cc58b4f48324ab90816b8199dda6