### PR TITLE
Print flow directory path at start

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -271,6 +271,7 @@ def orchestrate(
 
     for flow_conf in flow_configs:
         flow_dir = Path(tempfile.mkdtemp(prefix="flow_", dir=GENERATED_DIR))
+        print(flow_dir.resolve())
         while True:
             with progress_lock:
                 active = len([t for t in threads if t.is_alive()])


### PR DESCRIPTION
## Summary
- Print the absolute path of each flow directory as soon as it is created, allowing users to know where outputs are stored.

## Testing
- `python -m py_compile orchestrator.py openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ce4636448324b78d8f4682cd619e