### PR TITLE
Fix placeholder replacement for prompt files

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -43,7 +43,7 @@ def _run_flow(
         try:
             prompt = step.get("prompt", "")
             prmpt_file = step.get("prmpt_file")
-            if prmpt_file:
+            if prmpt_file and not prompt:
                 prompt = Path(prmpt_file).read_text(encoding="utf-8")
             if prev_output:
                 prompt = f"{prompt}\n{prev_output}".strip()

--- a/tests/test_prmpt_file_placeholders.py
+++ b/tests/test_prmpt_file_placeholders.py
@@ -1,0 +1,27 @@
+import threading
+from pathlib import Path
+
+import orchestrator
+
+
+def fake_api(prompt: str) -> dict:
+    return {"output": [{"content": [{"text": prompt}]}]}
+
+
+def test_prmpt_file_placeholders(tmp_path, monkeypatch):
+    template = tmp_path / "template.txt"
+    template.write_text("Hello {{{name}}}!", encoding="utf-8")
+
+    names_file = tmp_path / "names.txt"
+    names_file.write_text(str(tmp_path / "name.txt") + "\n", encoding="utf-8")
+
+    (tmp_path / "name.txt").write_text("World", encoding="utf-8")
+
+    base_config = [{"type": "openai", "prmpt_file": str(template)}]
+    key_files = {"name": names_file}
+    flows = orchestrator._generate_flow_configs(base_config, key_files)
+
+    monkeypatch.setattr(orchestrator, "call_openai_api", fake_api)
+
+    res = orchestrator._run_flow(flows[0], [0], threading.Lock(), tmp_path, tmp_path)
+    assert res[0][0] == "Hello World!"


### PR DESCRIPTION
## Summary
- avoid re-reading prompt files when prompt text already supplied
- add regression test to ensure `prmpt_file` placeholders are interpolated

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5cf296afc83248fdb7aefd980af1f