### PR TITLE
Save stdout of cmd stages to flow directories

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -71,6 +71,8 @@ def _run_flow(
                     check=True,
                 )
                 output = completed.stdout
+                stdout_file = curr_dir / f"step_{idx}_cmd.txt"
+                stdout_file.write_text(output, encoding="utf-8")
                 path = None
             else:
                 raise ValueError(f"Unknown step type: {step_type}")

--- a/tests/test_cmd_output_saved.py
+++ b/tests/test_cmd_output_saved.py
@@ -1,0 +1,15 @@
+import threading
+from pathlib import Path
+import orchestrator
+
+def test_cmd_output_saved(tmp_path):
+    config = [
+        {"type": "cmd", "cmd": "printf '[\"a\",\"b\"]'", "array": True},
+        {"type": "cmd", "cmd": "cat"},
+    ]
+    results = orchestrator._run_flow(config, [0, 0], threading.Lock(), tmp_path, tmp_path)
+
+    assert (tmp_path / "step_0_cmd.txt").read_text() == '["a","b"]'
+    assert (tmp_path / "branch_0" / "step_1_cmd.txt").read_text() == "a"
+    assert (tmp_path / "branch_1" / "step_1_cmd.txt").read_text() == "b"
+    assert sorted(r[0] for r in results) == ["a", "b"]


### PR DESCRIPTION
## Summary
- Persist stdout from `cmd` steps to `step_<index>_cmd.txt` within the current flow or branch directory
- Test that cmd step stdout is saved for branches

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70c16e7908324b15d5f6e2bdfc7ed