### PR TITLE
Track flow failures and enforce cancellation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_cmd_output_saved.py
+++ b/tests/test_cmd_output_saved.py
@@ -7,9 +7,12 @@ def test_cmd_output_saved(tmp_path):
         {"type": "cmd", "cmd": "printf '[\"a\",\"b\"]'", "array": True},
         {"type": "cmd", "cmd": "cat"},
     ]
-    results = orchestrator._run_flow(config, [0, 0], threading.Lock(), tmp_path, tmp_path)
+    results, failed = orchestrator._run_flow(
+        config, [0, 0], threading.Lock(), tmp_path, tmp_path
+    )
 
     assert (tmp_path / "step_0_cmd.txt").read_text() == '["a","b"]'
     assert (tmp_path / "branch_0" / "step_1_cmd.txt").read_text() == "a"
     assert (tmp_path / "branch_1" / "step_1_cmd.txt").read_text() == "b"
     assert sorted(r[0] for r in results) == ["a", "b"]
+    assert not failed

--- a/tests/test_flow_failures.py
+++ b/tests/test_flow_failures.py
@@ -1,0 +1,39 @@
+import threading
+
+import pytest
+
+import orchestrator
+
+
+def test_flow_failure_marks_directory(tmp_path):
+    config = [{"type": "cmd", "cmd": "false"}]
+
+    results, failed = orchestrator._run_flow(
+        config, [0], threading.Lock(), tmp_path, tmp_path
+    )
+
+    assert failed
+    assert results[0][1] is not None
+    assert (tmp_path / "flow_failed.txt").exists()
+    assert "errors" in str(results[0][1])
+
+
+def _copy_flow(base_config):
+    return [dict(step) for step in base_config]
+
+
+def test_orchestrate_stops_after_max_failures(tmp_path, capsys):
+    base_config = [{"type": "cmd", "cmd": "false"}]
+    flow_configs = [_copy_flow(base_config) for _ in range(4)]
+
+    with pytest.raises(orchestrator.MaxFlowFailuresExceeded):
+        orchestrator.orchestrate(
+            base_config,
+            flow_configs,
+            parallel=2,
+            workdir=tmp_path,
+            max_flow_failures=2,
+        )
+
+    captured = capsys.readouterr()
+    assert "Maximum flow failures reached" in captured.out

--- a/tests/test_prmpt_file_placeholders.py
+++ b/tests/test_prmpt_file_placeholders.py
@@ -23,5 +23,8 @@ def test_prmpt_file_placeholders(tmp_path, monkeypatch):
 
     monkeypatch.setattr(orchestrator, "call_openai_api", fake_api)
 
-    res = orchestrator._run_flow(flows[0], [0], threading.Lock(), tmp_path, tmp_path)
+    res, failed = orchestrator._run_flow(
+        flows[0], [0], threading.Lock(), tmp_path, tmp_path
+    )
+    assert not failed
     assert res[0][0] == "Hello World!"


### PR DESCRIPTION
## Summary
- track per-flow failures, mark their directories, and propagate cancellation support through `_run_flow`
- enforce a configurable maximum flow failure threshold in `orchestrate`, emit a clear message, and expose `--max-flow-failures`
- add fallbacks for missing OpenAI/requests dependencies and expand tests to cover failure handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cafba984b88324b4d0050a66083b44