### PR TITLE
Add option to suppress flow directory output

### DIFF
--- a/tests/test_flow_failures.py
+++ b/tests/test_flow_failures.py
@@ -37,3 +37,21 @@ def test_orchestrate_stops_after_max_failures(tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert "Maximum flow failures reached" in captured.out
+
+
+def test_orchestrate_can_disable_flow_path_output(tmp_path, capsys, monkeypatch):
+    base_config = [{"type": "cmd", "cmd": "printf hi"}]
+    flow_configs = [_copy_flow(base_config)]
+
+    monkeypatch.setattr(orchestrator, "GENERATED_DIR", tmp_path)
+
+    orchestrator.orchestrate(
+        base_config,
+        flow_configs,
+        parallel=1,
+        workdir=tmp_path,
+        print_flow_paths=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "flow_" not in captured.out


### PR DESCRIPTION
## Summary
- add a `print_flow_paths` flag to `orchestrate` so flow directory paths can be optionally suppressed
- expose a `--hide-flow-paths` CLI option that disables printing the flow directory paths
- cover the new flag with a unit test to ensure paths are hidden when requested

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1888f7a08324b8d59d3bb5e7ef10