### PR TITLE
Restrict workdir usage to Codex CLI

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -87,7 +87,6 @@ def _run_flow(
                     capture_output=True,
                     text=True,
                     shell=True,
-                    cwd=workdir,
                     check=True,
                 )
                 output = completed.stdout

--- a/tests/test_cmd_output_saved.py
+++ b/tests/test_cmd_output_saved.py
@@ -16,3 +16,24 @@ def test_cmd_output_saved(tmp_path):
     assert (tmp_path / "branch_1" / "step_1_cmd.txt").read_text() == "b"
     assert sorted(r[0] for r in results) == ["a", "b"]
     assert not failed
+
+
+def test_cmd_respects_process_cwd(tmp_path, monkeypatch):
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+    data_file = default_dir / "data.txt"
+    data_file.write_text("hello", encoding="utf-8")
+
+    monkeypatch.chdir(default_dir)
+
+    config = [{"type": "cmd", "cmd": "cat data.txt"}]
+
+    results, failed = orchestrator._run_flow(
+        config, [0], threading.Lock(), workdir, tmp_path
+    )
+
+    assert not failed
+    assert results[0][0] == "hello"


### PR DESCRIPTION
## Summary
- ensure command steps no longer inherit the configured Codex workdir
- add a regression test covering the updated command execution behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1f53863c8324a0aa146a8986cc57