### PR TITLE
Handle missing codex final message file

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -147,7 +147,17 @@ def run_codex_cli(
                         proc.returncode, proc.args, stderr=msg
                     )
 
-                return output_path.read_text(encoding="utf-8"), output_path
+                if output_path.exists():
+                    message = output_path.read_text(encoding="utf-8")
+                elif stdout_path.exists():
+                    message = stdout_path.read_text(encoding="utf-8")
+                    output_path.write_text(message, encoding="utf-8")
+                else:
+                    raise FileNotFoundError(
+                        "Codex CLI did not produce a final message file or stdout output"
+                    )
+
+                return message, output_path
         except subprocess.CalledProcessError as e:
             # Include stderr from the Codex CLI in the raised exception for logging.
             msg = e.stderr or str(e)

--- a/tests/test_run_codex_cli.py
+++ b/tests/test_run_codex_cli.py
@@ -1,0 +1,38 @@
+import io
+
+import openai_utils
+
+
+def test_run_codex_cli_falls_back_to_stdout(tmp_path, monkeypatch):
+    prompts = []
+
+    def fake_popen(cmd, stdout, stderr, text):
+        prompts.append(cmd[-1])
+
+        class DummyProcess:
+            def __init__(self) -> None:
+                self.args = cmd
+                self.returncode = 0
+                self.stdout = io.StringIO("final output\n")
+                self.stderr = io.StringIO("")
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                return None
+
+        return DummyProcess()
+
+    monkeypatch.setattr(openai_utils.subprocess, "Popen", fake_popen)
+
+    message, path = openai_utils.run_codex_cli("Test prompt", tmp_path, tmp_path)
+
+    assert prompts == ["Test prompt"]
+    assert path.read_text(encoding="utf-8") == "final output\n"
+    assert message == "final output\n"
+
+    exec_dirs = list(tmp_path.glob("codex_exec_*"))
+    assert len(exec_dirs) == 1
+    stdout_path = exec_dirs[0] / "stdout.txt"
+    assert stdout_path.read_text(encoding="utf-8") == "final output\n"


### PR DESCRIPTION
## Summary
- ensure `run_codex_cli` falls back to stdout output when the Codex CLI does not write a final message file
- add a regression test that verifies the fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb22b3cb448324ab21affc9debd9dc