### PR TITLE
Group flow outputs under run directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,17 @@ indicating one flow is at the first step and another is nearing completion at
 the final step.
 
 Each step receives the output of the previous step appended to its prompt. Each
-flow has its own directory inside `generated`, and Codex invocations create
-subdirectories within that flow. During execution, the Codex process's standard
-output is streamed to `stdout.txt` in its subdirectory. When the final step is
-handled by the codex CLI, its concluding message is written to
-`final_message.txt` in the same location so it remains available after the run.
-The script prints the path so downstream code can read the message:
+orchestrator invocation creates a dedicated `run_xxxx` directory inside
+`generated`, and flows are stored beneath that run directory (for example,
+`generated/run_1234/flow_5678`). Codex invocations create subdirectories within
+each flow. During execution, the Codex process's standard output is streamed to
+`stdout.txt` in its subdirectory. When the final step is handled by the codex
+CLI, its concluding message is written to `final_message.txt` in the same
+location so it remains available after the run. The script prints the path so
+downstream code can read the message:
 
 ```python
-with open("generated/flow_xxxx/codex_exec_xxxx/final_message.txt") as f:
+with open("generated/run_xxxx/flow_xxxx/codex_exec_xxxx/final_message.txt") as f:
     final_message = f.read()
 ```
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -344,6 +344,8 @@ def orchestrate(
             display = prog
         print(display)
 
+    run_dir = Path(tempfile.mkdtemp(prefix="run_", dir=GENERATED_DIR))
+
     threads: List[threading.Thread] = []
     monitor_thread = threading.Thread(target=monitor)
     monitor_thread.start()
@@ -351,7 +353,7 @@ def orchestrate(
     for flow_conf in flow_configs:
         if cancel_event.is_set():
             break
-        flow_dir = Path(tempfile.mkdtemp(prefix="flow_", dir=GENERATED_DIR))
+        flow_dir = Path(tempfile.mkdtemp(prefix="flow_", dir=run_dir))
         if print_flow_paths:
             print(flow_dir.resolve())
         while True:


### PR DESCRIPTION
## Summary
- create a per-run directory under `generated` and store flow outputs beneath it
- refresh the documentation to describe the new run/flow directory layout
- add a regression test confirming flows from one run share the same run directory

## Testing
- pytest
- pytest tests/test_flow_failures.py::test_orchestrate_groups_flows_in_run_directory

------
https://chatgpt.com/codex/tasks/task_e_68cb3816c1a88324a6c39159670fffcc