### PR TITLE
Add timing metadata for Codex stdout fallback

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -93,7 +93,9 @@ def run_codex_cli(
         tmpdir = Path(tempfile.mkdtemp(prefix="codex_exec_", dir=output_dir))
         output_path = tmpdir / "final_message.txt"
         stdout_path = tmpdir / "stdout.txt"
+        time_path = tmpdir / "time.txt"
         try:
+            start_time = time.time()
             with stdout_path.open("w", encoding="utf-8") as out_f:
                 proc = subprocess.Popen(
                     [
@@ -141,6 +143,8 @@ def run_codex_cli(
                 t_out.join()
                 t_err.join()
 
+                duration = time.time() - start_time
+
                 if proc.returncode != 0:
                     msg = "".join(stderr_lines) or str(proc.returncode)
                     raise subprocess.CalledProcessError(
@@ -152,6 +156,9 @@ def run_codex_cli(
                 elif stdout_path.exists():
                     message = stdout_path.read_text(encoding="utf-8")
                     output_path.write_text(message, encoding="utf-8")
+                    time_path.write_text(
+                        f"{proc.returncode}\n{duration}\n", encoding="utf-8"
+                    )
                 else:
                     raise FileNotFoundError(
                         "Codex CLI did not produce a final message file or stdout output"

--- a/tests/test_run_codex_cli.py
+++ b/tests/test_run_codex_cli.py
@@ -36,3 +36,10 @@ def test_run_codex_cli_falls_back_to_stdout(tmp_path, monkeypatch):
     assert len(exec_dirs) == 1
     stdout_path = exec_dirs[0] / "stdout.txt"
     assert stdout_path.read_text(encoding="utf-8") == "final output\n"
+    time_path = exec_dirs[0] / "time.txt"
+    time_contents = [
+        line for line in time_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert len(time_contents) >= 2
+    assert time_contents[0] == "0"
+    assert float(time_contents[1]) >= 0


### PR DESCRIPTION
## Summary
- record the Codex return code and runtime in a new time.txt when stdout fallback is used
- update the Codex CLI fallback unit test to cover the timing artifact

## Testing
- pytest tests/test_run_codex_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cb495c26b88324b7af2d42cf7c2e45