### PR TITLE
Add option to continue after flow failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ with open("generated/run_xxxx/flow_xxxx/codex_exec_xxxx/final_message.txt") as f
 
 Each flow directory is left intact for logging.
 
+The orchestrator stops scheduling new flows once the number of failed flows
+reaches the `--max-flow-failures` threshold (default `3`) and exits with a
+non-zero code. Pass `--ignore-max-failures` to keep running remaining flows and
+receive the full set of results even if more than the configured number of
+flows fail.
+
 ### Branching with arrays
 
 Add an `"array": true` field to any step that is expected to produce a JSON


### PR DESCRIPTION
## Summary
- add a halt_on_max_failures flag to orchestrate so failing flows no longer freeze the queue unless desired
- wire a --ignore-max-failures CLI flag and update the README with the new behaviour
- extend the flow failure tests with coverage for the new option and CLI flag

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd7a2248a4832491bd397f3153922a