### PR TITLE
Enable optional OpenAI web search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Create a JSON configuration describing each step. For built-in model calls, each
 item requires a `type` (`"codex"` or `"openai"`) and either a `prompt` or a
 `prmpt_file` pointing to a file containing the prompt. You can optionally
 include a `name` to use in the live progress output instead of the step type.
+For OpenAI stages, set `"web_search": true` to enable the hosted web search
+tool when generating a response.
 Steps may also include a `cmd` field to run an arbitrary shell
 command; the previous step's output is piped to the command's standard input and
 its standard output is passed to the next step.

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -174,11 +174,17 @@ def run_codex_cli(
             raise
 
 
-def call_openai_api(prompt: str, max_retries: int = 3) -> dict:
+def call_openai_api(
+    prompt: str,
+    *,
+    web_search: bool = False,
+    max_retries: int = 3,
+) -> dict:
     """Call the OpenAI Responses API with retry logic on network errors.
 
     Args:
         prompt: Prompt string for the response request.
+        web_search: When ``True``, enable hosted web search for the response.
         max_retries: Maximum number of retries on network-related errors.
 
     Returns:
@@ -193,7 +199,10 @@ def call_openai_api(prompt: str, max_retries: int = 3) -> dict:
 
     for attempt in range(max_retries):
         try:
-            response = client.responses.create(model="gpt-4o-mini", input=prompt)
+            request_args = {"model": "gpt-4o-mini", "input": prompt}
+            if web_search:
+                request_args["tools"] = [{"type": "web_search"}]
+            response = client.responses.create(**request_args)
             return response.model_dump()
         except NETWORK_EXCEPTIONS:
             if attempt == max_retries - 1:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -87,7 +87,8 @@ def _run_flow(
                     prompt, workdir, curr_dir, timeout=codex_timeout
                 )
             elif step_type == "openai":
-                response = call_openai_api(prompt)
+                web_search_enabled = step.get("web_search") is True
+                response = call_openai_api(prompt, web_search=web_search_enabled)
                 output = (
                     response.get("output", [{}])[0]
                     .get("content", [{}])[0]

--- a/tests/test_openai_web_search.py
+++ b/tests/test_openai_web_search.py
@@ -1,0 +1,33 @@
+import threading
+
+import orchestrator
+
+
+def test_openai_web_search_flag(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_api(prompt: str, *, web_search: bool = False, max_retries: int = 3) -> dict:
+        calls.append((prompt, web_search))
+        return {"output": [{"content": [{"text": prompt}]}]}
+
+    monkeypatch.setattr(orchestrator, "call_openai_api", fake_api)
+
+    flow_dir = tmp_path / "flow"
+    flow_dir.mkdir()
+
+    res, failed = orchestrator._run_flow(
+        [
+            {"type": "openai", "prompt": "First", "web_search": True},
+            {"type": "openai", "prompt": "Second"},
+        ],
+        [0, 0],
+        threading.Lock(),
+        tmp_path,
+        flow_dir,
+    )
+
+    assert not failed
+    assert len(res) == 1
+    assert len(calls) == 2
+    assert calls[0][1] is True
+    assert calls[1][1] is False

--- a/tests/test_prmpt_file_placeholders.py
+++ b/tests/test_prmpt_file_placeholders.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import orchestrator
 
 
-def fake_api(prompt: str) -> dict:
+def fake_api(prompt: str, *, web_search: bool = False, max_retries: int = 3) -> dict:
+    assert not web_search
     return {"output": [{"content": [{"text": prompt}]}]}
 
 


### PR DESCRIPTION
## Summary
- add support for the `web_search` flag on OpenAI stages so flows can enable hosted search tools
- update the OpenAI client helper to pass the search tool when requested and document the new option
- cover the new flag with focused and existing tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf7f58baec83249a5e304c66bf7fc0