### PR TITLE
Allow configuring OpenAI request options from CLI

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -179,6 +179,9 @@ def call_openai_api(
     *,
     web_search: bool = False,
     max_retries: int = 3,
+    model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    service_tier: Optional[str] = None,
 ) -> dict:
     """Call the OpenAI Responses API with retry logic on network errors.
 
@@ -199,7 +202,11 @@ def call_openai_api(
 
     for attempt in range(max_retries):
         try:
-            request_args = {"model": "gpt-4o-mini", "input": prompt}
+            request_args = {"model": model or "gpt-4o-mini", "input": prompt}
+            if reasoning_effort:
+                request_args["reasoning"] = {"effort": reasoning_effort}
+            if service_tier:
+                request_args["service_tier"] = service_tier
             if web_search:
                 request_args["tools"] = [{"type": "web_search"}]
             response = client.responses.create(**request_args)

--- a/tests/test_openai_web_search.py
+++ b/tests/test_openai_web_search.py
@@ -6,8 +6,24 @@ import orchestrator
 def test_openai_web_search_flag(tmp_path, monkeypatch):
     calls = []
 
-    def fake_api(prompt: str, *, web_search: bool = False, max_retries: int = 3) -> dict:
-        calls.append((prompt, web_search))
+    def fake_api(
+        prompt: str,
+        *,
+        web_search: bool = False,
+        max_retries: int = 3,
+        model=None,
+        reasoning_effort=None,
+        service_tier=None,
+    ) -> dict:
+        calls.append(
+            {
+                "prompt": prompt,
+                "web_search": web_search,
+                "model": model,
+                "reasoning_effort": reasoning_effort,
+                "service_tier": service_tier,
+            }
+        )
         return {"output": [{"content": [{"text": prompt}]}]}
 
     monkeypatch.setattr(orchestrator, "call_openai_api", fake_api)
@@ -29,5 +45,58 @@ def test_openai_web_search_flag(tmp_path, monkeypatch):
     assert not failed
     assert len(res) == 1
     assert len(calls) == 2
-    assert calls[0][1] is True
-    assert calls[1][1] is False
+    assert calls[0]["web_search"] is True
+    assert calls[1]["web_search"] is False
+    assert calls[0]["model"] is None
+    assert calls[0]["reasoning_effort"] is None
+    assert calls[0]["service_tier"] is None
+
+
+def test_openai_request_options_forwarding(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_api(
+        prompt: str,
+        *,
+        web_search: bool = False,
+        max_retries: int = 3,
+        model=None,
+        reasoning_effort=None,
+        service_tier=None,
+    ) -> dict:
+        calls.append(
+            {
+                "prompt": prompt,
+                "web_search": web_search,
+                "model": model,
+                "reasoning_effort": reasoning_effort,
+                "service_tier": service_tier,
+            }
+        )
+        return {"output": [{"content": [{"text": prompt}]}]}
+
+    monkeypatch.setattr(orchestrator, "call_openai_api", fake_api)
+
+    flow_dir = tmp_path / "flow"
+    flow_dir.mkdir()
+
+    res, failed = orchestrator._run_flow(
+        [{"type": "openai", "prompt": "Hello"}],
+        [0],
+        threading.Lock(),
+        tmp_path,
+        flow_dir,
+        openai_request_options={
+            "model": "gpt-test",
+            "service_tier": "scale",
+            "reasoning_effort": "medium",
+        },
+    )
+
+    assert not failed
+    assert res[0][0] == "Hello"
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["model"] == "gpt-test"
+    assert call["service_tier"] == "scale"
+    assert call["reasoning_effort"] == "medium"


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI model, service tier, and reasoning effort used for Responses API calls
- thread the new options through the flow runner and orchestrator entry points, including CLI arguments
- expand the OpenAI step tests to cover the new request options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf804e5bd4832492bcf78384818ed0