### PR TITLE
Switch OpenAI web search flag to preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ item requires a `type` (`"codex"` or `"openai"`) and either a `prompt` or a
 `prmpt_file` pointing to a file containing the prompt. You can optionally
 include a `name` to use in the live progress output instead of the step type.
 For OpenAI stages, set `"web_search": true` to enable the hosted web search
-tool when generating a response.
+preview tool when generating a response.
 Steps may also include a `cmd` field to run an arbitrary shell
 command; the previous step's output is piped to the command's standard input and
 its standard output is passed to the next step.

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -198,7 +198,7 @@ def call_openai_api(
 
     Args:
         prompt: Prompt string for the response request.
-        web_search: When ``True``, enable hosted web search for the response.
+        web_search: When ``True``, enable hosted web search preview for the response.
         max_retries: Maximum number of retries on network-related errors.
 
     Returns:
@@ -227,9 +227,11 @@ def call_openai_api(
                 request_args["service_tier"] = service_tier
             if web_search:
                 if WebSearchTool is not None:
-                    request_args["tools"] = [WebSearchTool(type="web_search")]
+                    request_args["tools"] = [
+                        WebSearchTool(type="web_search_preview")
+                    ]
                 else:  # pragma: no cover - fallback for older openai versions
-                    request_args["tools"] = [{"type": "web_search"}]
+                    request_args["tools"] = [{"type": "web_search_preview"}]
             response = client.responses.create(**request_args)
             return response.model_dump()
         except NETWORK_EXCEPTIONS:

--- a/tests/test_openai_web_search.py
+++ b/tests/test_openai_web_search.py
@@ -1,6 +1,9 @@
 import threading
 
+from types import SimpleNamespace
+
 import orchestrator
+import openai_utils
 
 
 def test_openai_web_search_flag(tmp_path, monkeypatch):
@@ -100,3 +103,51 @@ def test_openai_request_options_forwarding(tmp_path, monkeypatch):
     assert call["model"] == "gpt-test"
     assert call["service_tier"] == "scale"
     assert call["reasoning_effort"] == "medium"
+
+
+class _DummyResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def model_dump(self) -> dict:
+        return self._data
+
+
+class _DummyResponsesClient:
+    def __init__(self) -> None:
+        self.last_kwargs: dict = {}
+
+    def create(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.last_kwargs = kwargs
+        return _DummyResponse({"output": []})
+
+
+def test_call_openai_api_uses_preview_tool_with_type(monkeypatch):
+    dummy_responses = _DummyResponsesClient()
+    dummy_client = SimpleNamespace(responses=dummy_responses)
+    monkeypatch.setattr(openai_utils, "client", dummy_client)
+
+    class DummyWebSearchTool:
+        def __init__(self, *, type: str) -> None:
+            self.type = type
+
+    monkeypatch.setattr(openai_utils, "WebSearchTool", DummyWebSearchTool)
+
+    openai_utils.call_openai_api("Prompt", web_search=True)
+
+    tools = dummy_responses.last_kwargs.get("tools")
+    assert isinstance(tools, list)
+    assert len(tools) == 1
+    assert getattr(tools[0], "type") == "web_search_preview"
+
+
+def test_call_openai_api_uses_preview_tool_without_type(monkeypatch):
+    dummy_responses = _DummyResponsesClient()
+    dummy_client = SimpleNamespace(responses=dummy_responses)
+    monkeypatch.setattr(openai_utils, "client", dummy_client)
+    monkeypatch.setattr(openai_utils, "WebSearchTool", None)
+
+    openai_utils.call_openai_api("Prompt", web_search=True)
+
+    tools = dummy_responses.last_kwargs.get("tools")
+    assert tools == [{"type": "web_search_preview"}]


### PR DESCRIPTION
## Summary
- update the OpenAI helper to request the `web_search_preview` tool when web search is enabled and refresh documentation
- extend the OpenAI web search tests to cover the preview tool handling with and without the typed helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9e7590d883248554ac446f30d4d0