### PR TITLE
Add early exit handling for empty step responses

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -266,6 +266,18 @@ def _run_flow(
             with lock:
                 step_counts[idx] -= 1
 
+        exit_on_empty_response = step.get("exit_on_empty_response") is True
+        if exit_on_empty_response and not output.strip():
+            identifier = step.get("name") or f"step_{idx}"
+            message = (
+                "Exiting flow early: "
+                f"{identifier!s} produced an empty response."
+            )
+            print(message, flush=True)
+            log_path = curr_dir / f"step_{idx}_empty_response.txt"
+            log_path.write_text(message + "\n", encoding="utf-8")
+            return [("", log_path, curr_dir)]
+
         if step.get("array"):
             try:
                 items = json.loads(output)

--- a/tests/test_flow_failures.py
+++ b/tests/test_flow_failures.py
@@ -128,6 +128,44 @@ def test_cmd_failure_writes_stderr_file(tmp_path):
     assert "boom" in content
 
 
+def test_flow_exits_on_empty_response(tmp_path, capsys):
+    sentinel = tmp_path / "sentinel.txt"
+    base_config = [
+        {
+            "type": "cmd",
+            "cmd": "printf ''",
+            "exit_on_empty_response": True,
+            "name": "empty_step",
+        },
+        {
+            "type": "cmd",
+            "cmd": f"printf done > {shlex.quote(str(sentinel))}",
+        },
+    ]
+
+    results, failed = orchestrator._run_flow(
+        base_config,
+        [0 for _ in base_config],
+        threading.Lock(),
+        tmp_path,
+        tmp_path,
+    )
+
+    captured = capsys.readouterr()
+
+    assert not failed
+    assert not sentinel.exists()
+    assert "empty response" in captured.out.lower()
+
+    assert len(results) == 1
+    output, log_path, flow_dir = results[0]
+    assert output == ""
+    assert flow_dir == tmp_path
+    assert log_path is not None
+    assert log_path.read_text(encoding="utf-8").strip().endswith(
+        "empty_step produced an empty response."
+    )
+
 def test_codex_failure_writes_stderr_file(tmp_path, monkeypatch):
     def fake_run_codex_cli(prompt, workdir, output_dir, max_retries=3, timeout=None):
         err = subprocess.CalledProcessError(2, ["codex", "exec"], stderr="codex boom\n")


### PR DESCRIPTION
## Summary
- add support for an `exit_on_empty_response` flag on flow steps so empty outputs end the branch early with a log written to disk and stdout
- add coverage to ensure empty responses prevent later steps from running and produce the expected log file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63088d6c083248e197b85d2d6577b