### PR TITLE
Add stdin_file support for cmd steps

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -267,6 +267,14 @@ def _run_flow(
                         )
                         bucket_path.write_text(bucket_value, encoding="utf-8")
             elif "cmd" in step:
+                stdin_file = step.get("stdin_file")
+                if stdin_file:
+                    stdin_path = Path(stdin_file)
+                    stdin_content = stdin_path.read_text(encoding="utf-8")
+                    if step_input:
+                        step_input = "\n".join([step_input, stdin_content])
+                    else:
+                        step_input = stdin_content
                 completed = subprocess.run(
                     step["cmd"],
                     input=step_input,

--- a/tests/test_cmd_output_saved.py
+++ b/tests/test_cmd_output_saved.py
@@ -67,3 +67,23 @@ def test_cmd_inputs_accept_step_indexes(tmp_path):
 
     assert not failed
     assert results[0][0] == "bar\nfoo"
+
+
+def test_cmd_allows_stdin_file(tmp_path):
+    stdin_source = tmp_path / "input.txt"
+    stdin_source.write_text("hello from file", encoding="utf-8")
+
+    config = [{"type": "cmd", "cmd": "cat", "stdin_file": str(stdin_source)}]
+
+    flow_dir = tmp_path / "flow"
+    flow_dir.mkdir()
+
+    results, failed = orchestrator._run_flow(
+        config, [0], threading.Lock(), tmp_path, flow_dir
+    )
+
+    assert not failed
+    assert results[0][0] == "hello from file"
+    output_path = flow_dir / "step_0_cmd.txt"
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8") == "hello from file"


### PR DESCRIPTION
## Summary
- allow cmd steps to read stdin from a configured file via a new `stdin_file` key
- cover the new behavior with a regression test that verifies command output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddc1f6f5688324ba5633ffa8471584