### PR TITLE
Add helper for DigitalOcean CLI test droplet setup

### DIFF
--- a/docs/digitalocean-cli.md
+++ b/docs/digitalocean-cli.md
@@ -1,0 +1,45 @@
+# DigitalOcean CLI Setup
+
+This repository includes a helper script for configuring the [DigitalOcean CLI (`doctl`)](https://docs.digitalocean.com/reference/doctl/) and launching a tiny test droplet.
+
+## Installing `doctl`
+
+The CLI is not available in the default Ubuntu package repositories, so download the latest release archive directly from GitHub:
+
+```bash
+LATEST_TAG=$(curl -s https://api.github.com/repos/digitalocean/doctl/releases/latest | jq -r '.tag_name')
+curl -sL "https://github.com/digitalocean/doctl/releases/download/${LATEST_TAG}/doctl-${LATEST_TAG#v}-linux-amd64.tar.gz" -o doctl.tar.gz
+tar -xzf doctl.tar.gz
+sudo mv doctl /usr/local/bin/
+doctl version
+```
+
+## Authenticating and launching a test droplet
+
+1. Generate a DigitalOcean personal access token with read/write scopes and export it:
+
+   ```bash
+   export DIGITALOCEAN_ACCESS_TOKEN="<your-token>"
+   ```
+
+2. Determine the SSH key ID that should be added to the droplet and export it:
+
+   ```bash
+   export DIGITALOCEAN_SSH_KEY_ID="$(doctl compute ssh-key list --format ID --no-header | head -n 1)"
+   ```
+
+   Replace the command above if you need a specific key.
+
+3. Run the helper script to configure a `doctl` context and create a tiny test droplet:
+
+   ```bash
+   ./scripts/doctl-test-droplet.sh
+   ```
+
+   The script creates a `s-1vcpu-1gb` droplet in `nyc3`, waits for it to become active, and prints its ID and IPv4 address. The droplet is tagged with `test` so it can be cleaned up with:
+
+   ```bash
+   doctl compute droplet delete --tag-name test --force
+   ```
+
+> **Note:** The script requires valid credentials and SSH keys. Without them DigitalOcean will reject the API call, so it cannot be executed successfully within the automated test environment.

--- a/scripts/doctl-test-droplet.sh
+++ b/scripts/doctl-test-droplet.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v doctl >/dev/null 2>&1; then
+  echo "Error: doctl is not installed or not on PATH" >&2
+  exit 1
+fi
+
+: "${DIGITALOCEAN_ACCESS_TOKEN?DIGITALOCEAN_ACCESS_TOKEN environment variable must be set}"
+: "${DIGITALOCEAN_SSH_KEY_ID?DIGITALOCEAN_SSH_KEY_ID environment variable must be set}"
+
+CONTEXT_NAME="test-context"
+DROPLET_NAME="doctl-test-droplet"
+REGION="nyc3"
+SIZE="s-1vcpu-1gb"
+IMAGE="ubuntu-22-04-x64"
+
+# Configure the context so the test droplet uses scoped credentials.
+if ! doctl auth list 2>/dev/null | grep -q "^${CONTEXT_NAME}\\b"; then
+  doctl auth init --context "${CONTEXT_NAME}" --access-token "${DIGITALOCEAN_ACCESS_TOKEN}" >/dev/null
+fi
+
+doctl auth switch --context "${CONTEXT_NAME}" >/dev/null
+
+# Launch a tiny test droplet.
+doctl compute droplet create "${DROPLET_NAME}" \
+  --size "${SIZE}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --ssh-keys "${DIGITALOCEAN_SSH_KEY_ID}" \
+  --tag-names "test" \
+  --wait
+
+# Output connection details for follow-up automation.
+doctl compute droplet get "${DROPLET_NAME}" --format ID,Name,Status,PublicIPv4


### PR DESCRIPTION
## Summary
- document how to install and configure the DigitalOcean CLI for launching a test droplet
- add a helper script that authenticates a context and provisions a tiny test droplet via doctl

## Testing
- doctl version

------
https://chatgpt.com/codex/tasks/task_e_68e1347a156c83249b67c1952f10f7de